### PR TITLE
Recognize atom with a file extension.

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -40,7 +40,7 @@ function edit(path::AbstractString, line::Integer=0)
         background = false
     elseif name == "textmate" || name == "mate" || name == "kate"
         cmd = line != 0 ? `$command $path -l $line` : `$command $path`
-    elseif startswith(name, "subl") || name == "atom"
+    elseif startswith(name, "subl") || startswith(name, "atom")
         cmd = line != 0 ? `$command $path:$line` : `$command $path`
     elseif is_windows() && (name == "start" || name == "open")
         cmd = `cmd /c start /b $path`


### PR DESCRIPTION
The `edit` function on windows fails if the editor command is `atom`. It succeeds if it is instead `atom.cmd`, but then Julia fails to recognize the `atom` editor. This fixes that.
